### PR TITLE
cleanup + desktop icon visibility state persistence

### DIFF
--- a/Magic.xcodeproj/project.pbxproj
+++ b/Magic.xcodeproj/project.pbxproj
@@ -85,12 +85,13 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Jie Zhang";
 				TargetAttributes = {
 					18AEEA721F19B21D0053E830 = {
 						CreatedOnToolsVersion = 9.0;
-						ProvisioningStyle = Manual;
+						LastSwiftMigration = 1010;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -161,6 +162,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -168,6 +170,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -218,6 +221,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -225,6 +229,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -257,17 +262,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 4Z5Z5TE9EX;
+				DEVELOPMENT_TEAM = 9K7L5HQBR5;
 				INFOPLIST_FILE = Magic/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nsswift.Magic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -275,17 +280,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 4Z5Z5TE9EX;
+				DEVELOPMENT_TEAM = 9K7L5HQBR5;
 				INFOPLIST_FILE = Magic/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nsswift.Magic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -308,6 +313,7 @@
 				18AEEA831F19B21D0053E830 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Magic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Magic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Magic/AppDelegate.swift
+++ b/Magic/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 //    then the user would have to click the menubar item twice
 //    to make Desktop reappear
 
-    var isDesktopHidden: Bool {
+    var isDesktopShown: Bool {
         var finderPlistPath: URL?
 
         if #available(OSX 10.12, *) {
@@ -88,7 +88,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let process = Process()
         process.launchPath = "/bin/bash"
-        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(!isDesktopHidden); killall Finder"]
+        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(!isDesktopShown); killall Finder"]
         process.launch()
         print("Desktop State Flipped")
     }

--- a/Magic/AppDelegate.swift
+++ b/Magic/AppDelegate.swift
@@ -15,7 +15,53 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     let rightClickMenu = NSMenu()
 
-    var display = true
+//    var display = true
+//    this value does not persist
+//    when the app relauches, Desktop could be already hidden
+//    then the user would have to click the menubar item twice
+//    to make Desktop reappear
+    
+    var desktopShown: Bool {
+        var finderPlistPath: URL?
+        
+        if #available(OSX 10.12, *) {
+            finderPlistPath = FileManager().homeDirectoryForCurrentUser
+        } else {
+            // Fallback on earlier versions
+            finderPlistPath = URL(fileURLWithPath: NSHomeDirectory())
+        }
+        
+        finderPlistPath = finderPlistPath!.appendingPathComponent("Library/Preferences/com.apple.finder.plist")
+        
+//        if #available(OSX 10.13, *) {
+//            var dict: NSDictionary?
+//            do {
+//                dict = try NSDictionary(contentsOf: finderPlistPath!, error: ())
+//            } catch {
+//                print("Plist Convertion Error: \(error)")
+//            }
+//
+//            if let value = dict?.value(forKey: "CreateDesktop") as? Bool {
+//                return value
+//            }
+//        } else {
+//            // Fallback on earlier versions
+//
+//        }
+        
+        if let dict = NSDictionary(contentsOf: finderPlistPath!) {
+            return Bool(dict.value(forKey: "CreateDesktop") as! String)!
+//                  dict.value(forKey: "CreateDesktop") would produce
+//                  Any?, Bool initializer only accepts (Bool), (String), (NSNumber)
+//
+//                  dict.value(forKey: "CreateDesktop") as? Bool
+//                  does not work either, somehow the system would try to convert
+//                  dict.value(forKey: "CreateDesktop") NSTaggedPointerString
+//                  to NSNumber first, which fails.
+        }
+        
+        return false
+    }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
@@ -39,12 +85,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        display = !display
-
         let process = Process()
         process.launchPath = "/bin/bash"
-        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(display); killall Finder"]
+        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(!desktopShown); killall Finder"]
         process.launch()
+        print("Desktop State Flipped")
     }
 
     @objc func quitApp() {

--- a/Magic/AppDelegate.swift
+++ b/Magic/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 //    then the user would have to click the menubar item twice
 //    to make Desktop reappear
 
-    var desktopShown: Bool {
+    var isDesktopHidden: Bool {
         var finderPlistPath: URL?
 
         if #available(OSX 10.12, *) {
@@ -41,22 +41,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 print("Plist Convertion Error: \(error)")
             }
 
-            if let value = dict?.value(forKey: "CreateDesktop") as? String {
-                return Bool(value)!
+            if let value = dict?.value(forKey: "CreateDesktop") as? String,
+                let result = Bool(value) {
+                return result
             }
         } else {
             // Fallback on earlier versions
-            if let dict = NSDictionary(contentsOf: finderPlistPath!) {
-                return Bool(dict.value(forKey: "CreateDesktop") as! String)!
-                //                  dict.value(forKey: "CreateDesktop") would produce
-                //                  Any?, Bool initializer only accepts (Bool), (String), (NSNumber)
-                //
-                //                  dict.value(forKey: "CreateDesktop") as? Bool
-                //                  does not work either, somehow the system would try to convert
-                //                  dict.value(forKey: "CreateDesktop") NSTaggedPointerString
-                //                  to NSNumber first, which fails.
+            if let dict = NSDictionary(contentsOf: finderPlistPath!),
+                let value = dict.value(forKey: "CreateDesktop") as? String,
+                let result = Bool(value) {
+                return result
             }
-
+            //    dict.value(forKey: "CreateDesktop") would produce
+            //    Any?, Bool initializer only accepts (Bool), (String), (NSNumber)
+            //    dict.value(forKey: "CreateDesktop") as? Bool
+            //    does not work either, somehow the system would try to convert
+            //    dict.value(forKey: "CreateDesktop") NSTaggedPointerString
+            //    to NSNumber first, which fails.
         }
         
         return false
@@ -87,7 +88,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let process = Process()
         process.launchPath = "/bin/bash"
-        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(!desktopShown); killall Finder"]
+        process.arguments = ["-c", "defaults write com.apple.finder CreateDesktop \(!isDesktopHidden); killall Finder"]
         process.launch()
         print("Desktop State Flipped")
     }

--- a/Magic/AppDelegate.swift
+++ b/Magic/AppDelegate.swift
@@ -20,47 +20,47 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 //    when the app relauches, Desktop could be already hidden
 //    then the user would have to click the menubar item twice
 //    to make Desktop reappear
-    
+
     var desktopShown: Bool {
         var finderPlistPath: URL?
-        
+
         if #available(OSX 10.12, *) {
             finderPlistPath = FileManager().homeDirectoryForCurrentUser
         } else {
             // Fallback on earlier versions
             finderPlistPath = URL(fileURLWithPath: NSHomeDirectory())
         }
-        
+
         finderPlistPath = finderPlistPath!.appendingPathComponent("Library/Preferences/com.apple.finder.plist")
-        
-//        if #available(OSX 10.13, *) {
-//            var dict: NSDictionary?
-//            do {
-//                dict = try NSDictionary(contentsOf: finderPlistPath!, error: ())
-//            } catch {
-//                print("Plist Convertion Error: \(error)")
-//            }
-//
-//            if let value = dict?.value(forKey: "CreateDesktop") as? Bool {
-//                return value
-//            }
-//        } else {
-//            // Fallback on earlier versions
-//
-//        }
-        
-        if let dict = NSDictionary(contentsOf: finderPlistPath!) {
-            return Bool(dict.value(forKey: "CreateDesktop") as! String)!
-//                  dict.value(forKey: "CreateDesktop") would produce
-//                  Any?, Bool initializer only accepts (Bool), (String), (NSNumber)
-//
-//                  dict.value(forKey: "CreateDesktop") as? Bool
-//                  does not work either, somehow the system would try to convert
-//                  dict.value(forKey: "CreateDesktop") NSTaggedPointerString
-//                  to NSNumber first, which fails.
+
+        if #available(OSX 10.13, *) {
+            var dict: NSDictionary?
+            do {
+                dict = try NSDictionary(contentsOf: finderPlistPath!, error: ())
+            } catch {
+                print("Plist Convertion Error: \(error)")
+            }
+
+            if let value = dict?.value(forKey: "CreateDesktop") as? String {
+                return Bool(value)!
+            }
+        } else {
+            // Fallback on earlier versions
+            if let dict = NSDictionary(contentsOf: finderPlistPath!) {
+                return Bool(dict.value(forKey: "CreateDesktop") as! String)!
+                //                  dict.value(forKey: "CreateDesktop") would produce
+                //                  Any?, Bool initializer only accepts (Bool), (String), (NSNumber)
+                //
+                //                  dict.value(forKey: "CreateDesktop") as? Bool
+                //                  does not work either, somehow the system would try to convert
+                //                  dict.value(forKey: "CreateDesktop") NSTaggedPointerString
+                //                  to NSNumber first, which fails.
+            }
+
         }
         
         return false
+        
     }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {

--- a/Magic/Base.lproj/MainMenu.xib
+++ b/Magic/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13156.6" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13156.6"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -629,7 +629,7 @@
                             <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                 <connections>
-                                    <action selector="toggleSourceList:" target="-1" id="iwa-gc-5KM"/>
+                                    <action selector="toggleSidebar:" target="-1" id="iwa-gc-5KM"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
@@ -684,7 +684,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1129"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1080"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
1. changed the name of the variable, that is used to track desktop icon visibility state, so as to make it less cryptic

before: `desktop` after: `isDesktopShown`

2. change `isDesktopShown` from a stored property to a computed property so that each time this variable is accessed, it reflects the current desktop icon visibility state. Also, this makes sure the state data is persisted after app relaunch, otherwise the user might have to click the menubar icon twice before the state is flipped back to True